### PR TITLE
Update GenerateFridaSnippetForDex.py

### DIFF
--- a/scripts/GenerateFridaSnippetForDex.py
+++ b/scripts/GenerateFridaSnippetForDex.py
@@ -55,8 +55,10 @@ class GenerateFridaSnippetForDex(IScript):
       partypes.append(partype.getSignature(False, False))
       parnames.append("arg%d" % i)  # TODO: retrieve the decompiler-provided param names
 
-    no_return = m.getReturnType().isVoid()
-
+    no_return = False
+    if m.getReturnType().getName() == 'void':
+      no_return = True
+    
     # the tag rendered in the console will use the method's actual names (i.e. the renames if any), not the original names
     tag = "%s.%s" % (m.getClassType().getSignature(True, False, False), m.getName(True))
 


### PR DESCRIPTION
IsVoid no longer exists ? 
Replacing it with a check on the name of the type.

[E] Script execution error: com.pnfsoftware.jeb.client.script.ScriptExecutionException: Traceback (most recent call last):
[E]   File "/jeb5/scripts/samples/GenerateFridaSnippetForDex.py", line 58, in run
[E]     no_return = m.getReturnType().isVoid()
[E] AttributeError: 'com.pnfsoftware.jebglobal.xW' object has no attribute 'isVoid'
[E]