### PR TITLE
BugFix: Update TaskInWorkerThread.py

### DIFF
--- a/scripts/TaskInWorkerThread.py
+++ b/scripts/TaskInWorkerThread.py
@@ -11,16 +11,38 @@ class TaskInWorkerThread(IScript):
     if not isinstance(ctx, IGraphicalClientContext):
       print('This script must be run within a graphical client')
       return
-    # will start a worker thread and run the task; a pop-up will be shown to provide a way to interrupt the task
-    ctx.executeAsync('Counting...', SimpleTask())
-    print('Done.')
+    # will start a worker thread and run the task; 
+    # a pop-up will be shown to provide a way to interrupt the task
+    try:
+        ctx.executeAsync('Counting...', SimpleTask())
+        # under the hood com.pnfsoftware.jeb.util.concurrent.ThreadUtil.start( ) is used to launch the thread
+
+    except  (InterruptedException,KeyboardInterrupt,):
+        print('The task was interrupted')
+
+        #https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Thread.html#interrupt()
+        #"Interrupts this thread.
+        # If none of the previous conditions hold then this thread's interrupt status will be set."
+        #BUT
+        # If this thread is blocked in an invocation of the wait() ... join(), ... sleep..., then 
+        # its interrupt status will be cleared !!! 
+        # and it will receive an InterruptedException.
+        
+        # By this we set the missing interrupted status so SimpleTask gets the signal to stop
+        SimpleTask.WorkerThread_crutch.interrupt()
+    else:
+        print('Done.')
 
 class SimpleTask(Runnable):
   def run(self):
+    SimpleTask.WorkerThread_crutch=Thread.currentThread()
+    
     for i in range(10):
+      
       # react to user pressing Cancel
       if Thread.interrupted():
         print('The task was interrupted')
         break
+
       print('Counter: %d' % i)
       time.sleep(1)


### PR DESCRIPTION
Now it works again as intended:

```
Counter: 0
Counter: 1
Counter: 2
The task was interrupted
```
Before the output was this:

```
Counter: 0
Counter: 1
Counter: 2
[E] Script execution error: com.pnfsoftware.jeb.client.script.ScriptExecutionException: java.lang.InterruptedException 
[E] 	at java.base/java.lang.Object.wait(Native Method) 
[E] 	at java.base/java.lang.Thread.join(Thread.java:1309) 
[E] 	at com.pnfsoftware.jeb.util.concurrent.ThreadEx.get(SourceFile:88) 
[E] 	at com.pnfsoftware.jeb.rcpclient.extensions.ui.UITask.run(UITask.java:139) 
[E] 	at com.pnfsoftware.jeb.rcpclient.extensions.ui.TaskMonitorDialog$1.run(TaskMonitorDialog.java:214) 
[E] 	at java.base/java.lang.Thread.run(Thread.java:842) [E] java.lang.InterruptedException: java.lang.InterruptedException 
[E] 
Counter: 3
Counter: 4
SimpleTask Done.
```
Maybe alter the rcpclient in JEB so we don't need that bugfix anymore.

[UITask.java run()](https://pastebin.com/X1TASKss)
```
 137:           try {
 138:                if (this.runnable != null) {
 139:                    t.get(this.checkTimeoutMs);
 140:                } else {
 142:                    this.result = t.get(this.checkTimeoutMs);
 143:               }
 144:
 145:           } catch (java.lang.InterruptedException e) {
 146:               throw e;
```
Like this:
```
 145:           } catch (java.lang.InterruptedException e) {
 146:               t.interrupt()
 147:               throw e;
```
So the 'lost' interrupted flag from the thread, gets restored there.

Or patch [TaskMonitorDialog.java run()](https://pastebin.com/Jau9GijQ) in ya private JEB-repo.
That has at lines 271 and 272  (line 107 as paste.bin) a very similar error handler.

... so we don't need that bug fix more.
The code relates to JEB-5.18.0.2024_10_07__1909

However, be aware to not interrupt the 'wrong' thread. 
With that
```
class TaskInWorkerThread(IScript):

  def run(self, ctx):
    Thread.currentThread().interrupt()
    
```
I successfully 'lock' the entire JEB-Instance and needed to kill and start it again.